### PR TITLE
Add Github Action to Submit to Web Stores

### DIFF
--- a/.github/workflows/deploy_to_stores.yml
+++ b/.github/workflows/deploy_to_stores.yml
@@ -1,0 +1,16 @@
+on: workflow_dispatch
+
+name: Submit to Web Stores
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create zip
+        run: cd src/; zip -r ../extension.zip .; cd -
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          artifact: ./extension.zip
+          keys: ${{ secrets.SUBMIT_KEYS }}


### PR DESCRIPTION
Hey @steven2358, we made a Github action to make it easier to deploy to each of the web stores. This PR integrates reveye's repo to our Github action so you can deploy directly from the Github UI.

Currently supporting Chrome, Firefox, Edge, and Opera (Safari support coming soon too)

The only thing you would need to create is a `SUBMIT_KEYS` GitHub repository secret.

This secret is a JSON, with the schema defined [here](https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json).

Here's a sample key (added the correct zip locations for chrome and firefox here):

```
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "apiKey": "123",
    "apiSecret": "abcd",
    "extId": "foobar"
  }
}
```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me.

Otherwise, if this doesn't seem necessary, feel free to close the PR!